### PR TITLE
fix: 修复开启了 `strictNullChecks` 后，赋值为 `undefined` 和 `null` 的变量类型推断问题

### DIFF
--- a/docs/types.md
+++ b/docs/types.md
@@ -150,7 +150,7 @@ let c = null;        // any
 const d = null;      // null
 ```
 
-上面示例中，打开编译设置`strictNullChecks`以后，赋值为`undefined`的常量会被推断为`undefined`类型，赋值为`null`的变量会被推断为`null`类型；赋值为`undefined`和`null`的变量都会被推断为`any`类型。
+上面示例中，打开编译设置`strictNullChecks`以后，赋值为`undefined`的常量会被推断为`undefined`类型，赋值为`null`的常量会被推断为`null`类型；赋值为`undefined`和`null`的变量都会被推断为`any`类型。
 
 ## 包装对象类型
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -143,14 +143,14 @@ const d = null;      // any
 
 ```typescript
 // 打开编译设置 strictNullChecks
-let a = undefined;   // undefined
+let a = undefined;   // any
 const b = undefined; // undefined
 
-let c = null;        // null
+let c = null;        // any
 const d = null;      // null
 ```
 
-上面示例中，打开编译设置`strictNullChecks`以后，赋值为`undefined`的变量会被推断为`undefined`类型，赋值为`null`的变量会被推断为`null`类型。
+上面示例中，打开编译设置`strictNullChecks`以后，赋值为`undefined`的常量会被推断为`undefined`类型，赋值为`null`的变量会被推断为`null`类型；赋值为`undefined`和`null`的变量都会被推断为`any`类型。
 
 ## 包装对象类型
 


### PR DESCRIPTION
阮老师，这个地方经过实际测试，即使开启了 `strictNullChecks` 的选项后，如果给变量赋值为 `undefined` 或 `null` 之后，ts 编译器推断出来的类型仍然是 `any`。

<img width="261" alt="image" src="https://github.com/wangdoc/typescript-tutorial/assets/9007793/78c53d9f-c17e-410e-acce-85fed68f3d3c">

<img width="267" alt="image" src="https://github.com/wangdoc/typescript-tutorial/assets/9007793/8e878d32-9991-4cec-a478-3a345b5de03c">
