### PR TITLE
   docs: perfect title

### DIFF
--- a/docs/es6.md
+++ b/docs/es6.md
@@ -44,7 +44,7 @@ async function fn(): Promise<number> {
 }
 ```
 
-## `Iterable<>`
+## `Iterable<T>`
 
 对象只要部署了 Iterator 接口，就可以用`for...of`循环遍历。Generator 函数（生成器）返回的就是一个具有 Iterator 接口的对象。
 


### PR DESCRIPTION
以下基础的标题尖括号中都写着范型，这边的Iterable加上是不是更好呢，望采纳
![image](https://github.com/wangdoc/typescript-tutorial/assets/117748716/89823c4e-7549-4b29-ab5d-e784fe1644ce)
