### PR TITLE
fix: strictNullChecks描述

### DIFF
--- a/docs/types.md
+++ b/docs/types.md
@@ -129,7 +129,7 @@ const x:null = null;
 
 上面示例中，变量`x`就属于 null 类型。
 
-注意，如果没有声明类型的变量，被赋值为`undefined`或`null`，在关闭编译设置`noImplicitAny`和`strictNullChecks`时，它们的类型会被推断为`any`。
+注意，如果没有声明类型的变量，被赋值为`undefined`或`null`，在关闭编译设置`strictNullChecks`时，它们的类型会被推断为`any`。
 
 ```typescript
 // 关闭 noImplicitAny 和 strictNullChecks
@@ -141,10 +141,10 @@ let c = null;        // any
 const d = null;      // any
 ```
 
-如果希望避免这种情况，则需要打开编译选项`strictNullChecks`。
+如果希望避免这种情况，则需要打开编译选项`strictNullChecks`，且同时关闭编译选项`noImplicitAny`。
 
 ```typescript
-// 打开编译设置 strictNullChecks
+// 打开编译设置 strictNullChecks 关闭编译设置 noImplicitAny
 
 let a = undefined;   // undefined
 const b = undefined; // undefined


### PR DESCRIPTION
打开编译选项`strictNullChecks`，且同时关闭编译选项`noImplicitAny`，赋值为`undefined`的变量会被推断为`undefined`类型，赋值为`null`的变量会被推断为`null`类型。
![Snipaste_2024-04-10_14-14-44](https://github.com/wangdoc/typescript-tutorial/assets/31907940/827a1f9e-b6d8-4729-8915-e4522873fcc2)
![Snipaste_2024-04-10_14-23-07](https://github.com/wangdoc/typescript-tutorial/assets/31907940/fffd11a3-319b-4cf5-9124-3bb10f42a6f9)
